### PR TITLE
Build src/cfg_parse.h

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -6,6 +6,7 @@ oidentd_LDADD = -Lmissing -lmissing $(ADD_LIB)
 AM_CFLAGS = $(DEBUG_CFLAGS) $(WARN_CFLAGS)
 AM_CPPFLAGS = -I "$(srcdir)/missing" \
 	-D "SYSCONFDIR=\"$(sysconfdir)\""
+AM_YFLAGS = -d
 
 EXTRA_DIST = kernel
 
@@ -32,3 +33,6 @@ noinst_HEADERS = \
 	options.h	\
 	user_db.h	\
 	util.h
+
+BUILT_SOURCES = \
+	cfg_parse.h


### PR DESCRIPTION
Bison does not create header files by default. Current build script
would never (re)build src/cfg_parse.h from src/cfg_parse.y.

This patch asks Automake to generate it. See "Yacc and Lex support"
section in Automake info page.