### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/inet_util.c
+++ b/src/inet_util.c
@@ -400,7 +400,7 @@ inline bool sin4_equal(	struct sockaddr_storage *ss1,
 void sin_setv4(in_addr_t addr, struct sockaddr_storage *ss) {
 	memset(ss, 0, sizeof(struct sockaddr_storage));
 	ss->ss_family = AF_INET;
-	memcpy(&SIN4(ss)->sin_addr, &addr, sizeof(struct sockaddr_in));
+	memcpy(&SIN4(ss)->sin_addr, &addr, sizeof(addr));
 }
 
 #ifdef WANT_IPV6

--- a/src/kernel/linux.c
+++ b/src/kernel/linux.c
@@ -292,7 +292,11 @@ uid_t get_user6(	in_port_t lport,
 	}
 
 	/* Eat the header line. */
-	fgets(buf, sizeof(buf), fp);
+	if (NULL == fgets(buf, sizeof(buf), fp)) {
+		debug("fgets: %s: Could not read header", CFILE6);
+		fclose(fp);
+		return MISSING_UID;
+	}
 
 	while (fgets(buf, sizeof(buf), fp)) {
 		struct in6_addr remote6;
@@ -376,7 +380,11 @@ uid_t get_user4(	in_port_t lport,
 	}
 
 	/* Eat the header line. */
-	fgets(buf, sizeof(buf), fp);
+	if (NULL == fgets(buf, sizeof(buf), fp)) {
+		debug("fgets: %s: Could not read header", CFILE);
+		fclose(fp);
+		return MISSING_UID;
+	}
 
 	/*
 	** The line should never be longer than 1024 chars, so fgets should be OK.
@@ -477,7 +485,10 @@ bool masq(	int sock,
 
 	if (conntrack == CT_MASQFILE) {
 		/* eat the header line */
-		fgets(buf, sizeof(buf), masq_fp);
+		if (NULL == fgets(buf, sizeof(buf), masq_fp)) {
+			debug("fgets: conntrack file: Could not read header");
+			return false;
+		}
 	}
 
 	while (fgets(buf, sizeof(buf), masq_fp)) {

--- a/src/kernel/linux.c
+++ b/src/kernel/linux.c
@@ -730,6 +730,8 @@ static int masq_ct_line(char *line,
 
 		return 0;
 	}
+
+	return -1;
 }
 
 #endif


### PR DESCRIPTION
This patch set addresses various compiler warnings I obtained with GCC 8 and glibc 2.27.9000 on x86_64 linux.

The first patch (Fix out-of-bound read/write) is quite serious and it's a real bug.

The second patch (Check for fgets() failure) is good to have.

The last patch partially fixes an issue in masq_ct_lint(). Either the code is too complex for the compiler, or there is some mistake in the code branching. It would be great if you looked at it and finished the fix.

There are more warnings about unused variables and pointers to mismatched signed and unsigned chars. But these are not important. I can list them later in a separate issue.