### PR TITLE
Forward capability

### DIFF
--- a/doc/oidentd.conf.5
+++ b/doc/oidentd.conf.5
@@ -122,6 +122,9 @@ The capability argument must be one of the capabilities described in the
 The force action takes a third argument when the capability is \fIreply\fP. For
 example, \fIforce reply "randomuser"\fP.
 
+The force action takes four arguments when the capability is \fIforward\fP. For
+example, \fIforce forward 127.0.0.1 1113\fP.
+
 .SH $HOME/.oidentd.conf SYNTAX
 A user's \fB$HOME/.oidentd.conf\fP configuration file may contain 0 or more of
 the following statements:
@@ -147,7 +150,7 @@ manner.
 The range directive has the same syntax and semantics as the range directive in
 the \fB/etc/oidentd.conf\fP file. See above for a description.
 
-Valid capabilities are \fIreply\fP, \fIrandom\fP, \fInumeric\fP,
+Valid capabilities are \fIreply\fP, \fIforward\fP, \fIrandom\fP, \fInumeric\fP,
 \fIrandom_numeric\fP, and \fIhide\fP. Descriptions can be found below.
 
 .SH CAPABILITIES
@@ -231,6 +234,15 @@ The character with the ASCII code \fINNN\fP in the hexadecimal base system.
 .LP
 
 .TP
+\fBforward\fP <host> <port>
+Forward the request to the specified host and port. If not forced, the
+response is subject to the same spoofing checks as \fIreply\fP.
+.br
+If the request fails for any reason, reports a "HIDDEN-USER" error if the
+forward was forced or the user is allowed to \fIhide\fP. Otherwise, a failure
+is replaced with the real username.
+
+.TP
 .B hide
 Hide the user; report a "HIDDEN-USER" error when an ident lookup succeeds.
 
@@ -255,6 +267,7 @@ default {
 		deny spoof
 		deny spoof_all
 		deny spoof_privport
+		deny forward
 		allow random_numeric
 		allow numeric
 		allow hide
@@ -265,7 +278,7 @@ default {
 Grant all users the ability to generate random numeric ident replies, the
 ability to generate numeric ident replies and the ability to hide their
 identities on all ident queries. Explicitly deny the ability to spoof ident
-responses.
+responses or forward requests.
 
 .nf
 user root {
@@ -297,6 +310,17 @@ ability to use other usernames as ident replies, generate random replies and
 hide his ident for all connections, and grant the user "ryan" the capability to
 spoof ident replies to privileged ports (< 1024) on connections originating
 from the host 127.0.0.1.
+
+.nf
+user jester {
+	default {
+		force forward 127.0.0.1 1113
+	}
+}
+.fi
+
+Forward requests for connections belonging to the user "jester" to the server
+running at 127.0.0.1:1113.
 
 .SH EXAMPLE $HOME/.oidentd.conf FILE
 .nf

--- a/oidentd.conf
+++ b/oidentd.conf
@@ -18,6 +18,7 @@ default {
 		deny random_numeric
 		deny numeric
 		deny hide
+		deny forward
 	}
 }
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,6 +17,7 @@ oidentd_SOURCES = \
 	oidentd.c	\
 	util.c		\
 	inet_util.c	\
+	forward.c	\
 	user_db.c	\
 	options.c	\
 	masq.c		\
@@ -28,6 +29,7 @@ noinst_HEADERS = \
 	oidentd.h	\
 	cfg_parse.h	\
 	inet_util.h	\
+	forward.h	\
 	masq.h		\
 	netlink.h	\
 	options.h	\

--- a/src/cfg_parse.y
+++ b/src/cfg_parse.y
@@ -73,6 +73,7 @@ u_int16_t default_caps;
 %token TOK_LPORT
 %token TOK_FORCE
 %token TOK_REPLY
+%token TOK_FORWARD
 %token <value> TOK_ALLOWDENY
 %token <value> TOK_CAP
 %token <string> TOK_STRING
@@ -335,6 +336,36 @@ force_reply:
 	}
 ;
 
+force_forward:
+	TOK_FORCE TOK_FORWARD TOK_STRING TOK_STRING {
+		cur_cap->caps = CAP_FORWARD;
+		cur_cap->action = ACTION_FORCE;
+		cur_cap->data.forward.host = xmalloc(sizeof(struct sockaddr_storage));
+
+		if (get_addr($3, cur_cap->data.forward.host) == -1) {
+			if (parser_mode == PARSE_SYSTEM) {
+				o_log(LOG_CRIT, "[line %u] Bad address: \"%s\"",
+					current_line, $3);
+			}
+
+			free($3); free($4);
+			free_cap_entries(cur_cap);
+			YYABORT;
+		}
+
+		if (get_port($4, &cur_cap->data.forward.port) == -1) {
+			if (parser_mode == PARSE_SYSTEM)
+				o_log(LOG_CRIT, "[line %u] Bad port: \"%s\"", current_line, $4);
+
+			free($3); free($4);
+			free_cap_entries(cur_cap);
+			YYABORT;
+		}
+
+		free($3); free($4);
+	}
+;
+
 cap_statement:
 	TOK_FORCE TOK_CAP {
 		cur_cap->caps = $2;
@@ -343,11 +374,22 @@ cap_statement:
 |
 	force_reply
 |
+	force_forward
+|
 	TOK_ALLOWDENY TOK_CAP {
 		if ($1 == ACTION_ALLOW)
 			cur_cap->caps |= $2;
 		else
 			cur_cap->caps &= ~$2;
+
+		cur_cap->action = $1;
+	}
+|
+	TOK_ALLOWDENY TOK_FORWARD {
+		if ($1 == ACTION_ALLOW)
+			cur_cap->caps |= CAP_FORWARD;
+		else
+			cur_cap->caps &= ~CAP_FORWARD;
 
 		cur_cap->action = $1;
 	}
@@ -376,6 +418,35 @@ user_reply:
 	}
 ;
 
+user_forward:
+	TOK_FORWARD TOK_STRING TOK_STRING {
+		cur_cap->caps = CAP_FORWARD;
+		cur_cap->data.forward.host = xmalloc(sizeof(struct sockaddr_storage));
+
+		if (get_addr($2, cur_cap->data.forward.host) == -1) {
+			if (parser_mode == PARSE_SYSTEM) {
+				o_log(LOG_CRIT, "[line %u] Bad address: \"%s\"",
+					current_line, $2);
+			}
+
+			free($2); free($3);
+			free_cap_entries(cur_cap);
+			YYABORT;
+		}
+
+		if (get_port($3, &cur_cap->data.forward.port) == -1) {
+			if (parser_mode == PARSE_SYSTEM)
+				o_log(LOG_CRIT, "[line %u] Bad port: \"%s\"", current_line, $3);
+
+			free($2); free($3);
+			free_cap_entries(cur_cap);
+			YYABORT;
+		}
+
+		free($2); free($3);
+	}
+;
+
 user_cap_rule:
 	TOK_CAP {
 		if ($1 == CAP_SPOOF || $1 == CAP_SPOOF_ALL || $1 == CAP_SPOOF_PRIVPORT)
@@ -388,6 +459,8 @@ user_cap_rule:
 	}
 |
 	user_reply
+|
+	user_forward
 ;
 
 %%

--- a/src/cfg_parse.y
+++ b/src/cfg_parse.y
@@ -323,15 +323,15 @@ force_reply:
 	TOK_FORCE TOK_REPLY TOK_STRING {
 		cur_cap->caps = CAP_REPLY;
 		cur_cap->action = ACTION_FORCE;
-		cur_cap->force_data = xrealloc(cur_cap->force_data,
-			++cur_cap->num_replies * sizeof(u_char *));
-		cur_cap->force_data[cur_cap->num_replies - 1] = $3;
+		cur_cap->data.replies.data = xrealloc(cur_cap->data.replies.data,
+			++cur_cap->data.replies.num * sizeof(u_char *));
+		cur_cap->data.replies.data[cur_cap->data.replies.num - 1] = $3;
 	}
 |
 	force_reply TOK_STRING {
-		cur_cap->force_data = xrealloc(cur_cap->force_data,
-			++cur_cap->num_replies * sizeof(u_char *));
-		cur_cap->force_data[cur_cap->num_replies - 1] = $2;
+		cur_cap->data.replies.data = xrealloc(cur_cap->data.replies.data,
+			++cur_cap->data.replies.num * sizeof(u_char *));
+		cur_cap->data.replies.data[cur_cap->data.replies.num - 1] = $2;
 	}
 ;
 
@@ -362,16 +362,16 @@ user_range_rule:
 user_reply:
 	TOK_REPLY TOK_STRING {
 		cur_cap->caps = CAP_REPLY;
-		cur_cap->force_data = xrealloc(cur_cap->force_data,
-			++cur_cap->num_replies * sizeof(u_char *));
-		cur_cap->force_data[cur_cap->num_replies - 1] = $2;
+		cur_cap->data.replies.data = xrealloc(cur_cap->data.replies.data,
+			++cur_cap->data.replies.num * sizeof(u_char *));
+		cur_cap->data.replies.data[cur_cap->data.replies.num - 1] = $2;
 	}
 |
 	user_reply TOK_STRING {
-		if (cur_cap->num_replies < MAX_RANDOM_REPLIES) {
-			cur_cap->force_data = xrealloc(cur_cap->force_data,
-				++cur_cap->num_replies * sizeof(u_char *));
-			cur_cap->force_data[cur_cap->num_replies - 1] = $2;
+		if (cur_cap->data.replies.num < MAX_RANDOM_REPLIES) {
+			cur_cap->data.replies.data = xrealloc(cur_cap->data.replies.data,
+				++cur_cap->data.replies.num * sizeof(u_char *));
+			cur_cap->data.replies.data[cur_cap->data.replies.num - 1] = $2;
 		}
 	}
 ;

--- a/src/cfg_scan.l
+++ b/src/cfg_scan.l
@@ -81,6 +81,7 @@ RANDOM_NUMERIC		random_numeric
 SPOOF				spoof
 SPOOF_ALL			spoof_all
 SPOOF_PRIVPORT		spoof_privport
+FORWARD				forward
 
 %%
 
@@ -175,6 +176,10 @@ SPOOF_PRIVPORT		spoof_privport
 
 {REPLY} {
 	return (TOK_REPLY);
+}
+
+{FORWARD} {
+	return (TOK_FORWARD);
 }
 
 \" {

--- a/src/forward.c
+++ b/src/forward.c
@@ -1,0 +1,142 @@
+/*
+** oidentd_forward.c - oidentd request forwarding.
+** Copyright (c) 1998-2006 Ryan McCabe <ryan@numb.org>
+** Copyright (c) 2018      Janik Rabe  <oidentd@janikrabe.com>
+** Copyright (c) 2018      Jan Steffens <jan.steffens@gmail.com>
+**
+** This program is free software; you can redistribute it and/or modify
+** it under the terms of the GNU General Public License, version 2,
+** as published by the Free Software Foundation.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include <config.h>
+
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <setjmp.h>
+#include <syslog.h>
+#include <string.h>
+#include <errno.h>
+#include <pwd.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#include "oidentd.h"
+#include "util.h"
+#include "missing.h"
+#include "inet_util.h"
+#include "options.h"
+#include "forward.h"
+
+static sigjmp_buf timebuf;
+static int fsock;
+static void fwd_alarm(int sig) __noreturn;
+
+/*
+** Make an ident request to another machine and return its response,
+** if the request was successful.
+*/
+
+int forward_request(const struct sockaddr_storage *host,
+					in_port_t port,
+					in_port_t lport,
+					in_port_t fport,
+					char *reply,
+					size_t len)
+{
+	struct sockaddr_storage addr;
+	char ipbuf[MAX_IPLEN];
+	char user[512];
+	char buf[1024];
+
+	sin_copy(&addr, host);
+	sin_set_port(htons(port), &addr);
+
+	fsock = socket(addr.ss_family, SOCK_STREAM, 0);
+	if (fsock == -1) {
+		debug("socket: %s", strerror(errno));
+		return (-1);
+	}
+
+	if (sigsetjmp(timebuf, 1) != 0) {
+		debug("sigsetjmp: %s", strerror(errno));
+		return (-1);
+	}
+
+	signal(SIGALRM, fwd_alarm);
+
+	/*
+	** Five seconds should be plenty, seeing as we're forwarding to a machine
+	** on a local network.
+	*/
+
+	alarm(5);
+
+	if (connect(fsock, (struct sockaddr *) &addr, sin_len(&addr)) != 0) {
+		get_ip(&addr, ipbuf, sizeof(ipbuf));
+		debug("connect to %s:%d: %s",
+			ipbuf, ntohs(sin_port(&addr)), strerror(errno));
+		goto out_fail;
+	}
+
+	if (sockprintf(fsock, "%d , %d\r\n", lport, fport) < 1) {
+		debug("write: %s", strerror(errno));
+		goto out_fail;
+	}
+
+	if (!sock_read(fsock, buf, sizeof(buf))) {
+		debug("read(%d): %s\n", fsock, strerror(errno));
+		goto out_fail;
+	}
+
+	/*
+	** Don't time out once we've finished processing the request.
+	*/
+
+	alarm(0);
+	close(fsock);
+
+	if (sscanf(buf, "%*d , %*d : USERID :%*[^:]:%511s", user) != 1) {
+		char *p = strchr(buf, '\r');
+
+		if (p != NULL)
+			*p = '\0';
+
+		get_ip(&addr, ipbuf, sizeof(ipbuf));
+		debug("[%s] Remote response: \"%s\"", ipbuf, buf);
+		return (-1);
+	}
+
+	xstrncpy(reply, user, len);
+	return (0);
+
+out_fail:
+	alarm(0);
+	close(fsock);
+	return (-1);
+}
+
+/*
+** Handle the timeout of a forward request.
+*/
+
+static void fwd_alarm(int sig) {
+	o_log(NORMAL, "Forward timed out");
+	close(fsock);
+	siglongjmp(timebuf, sig);
+}
+

--- a/src/forward.h
+++ b/src/forward.h
@@ -1,0 +1,31 @@
+/*
+** oidentd_forward.h - oidentd request forwarding.
+** Copyright (c) 1998-2006 Ryan McCabe <ryan@numb.org>
+** Copyright (c) 2018      Janik Rabe  <oidentd@janikrabe.com>
+** Copyright (c) 2018      Jan Steffens <jan.steffens@gmail.com>
+**
+** This program is free software; you can redistribute it and/or modify
+** it under the terms of the GNU General Public License, version 2,
+** as published by the Free Software Foundation.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#ifndef __OIDENTD_FORWARD_H
+#define __OIDENTD_FORWARD_H
+
+int forward_request(const struct sockaddr_storage *host,
+					in_port_t port,
+					in_port_t lport,
+					in_port_t fport,
+					char *reply,
+					size_t len);
+
+#endif

--- a/src/options.c
+++ b/src/options.c
@@ -138,7 +138,6 @@ int get_options(int argc, char *const argv[]) {
 		o_log(LOG_CRIT, "Fatal: Bad port: \"%s\"", DEFAULT_FPORT);
 		return (-1);
 	}
-	fwdport = htons(fwdport);
 #endif
 
 	connection_limit = 0xffffffff;
@@ -208,7 +207,6 @@ int get_options(int argc, char *const argv[]) {
 					o_log(LOG_CRIT, "Fatal: Bad port: \"%s\"", p);
 					return (-1);
 				}
-				fwdport = htons(fwdport);
 
 				enable_opt(FORWARD);
 				break;

--- a/src/user_db.c
+++ b/src/user_db.c
@@ -97,7 +97,7 @@ static void random_ident(char *buf, size_t len) {
 */
 
 static inline u_char *select_reply(const struct user_cap *user) {
-	return (user->force_data[randval(user->num_replies)]);
+	return (user->data.replies.data[randval(user->data.replies.num)]);
 }
 
 /*
@@ -256,10 +256,11 @@ void user_db_cap_destroy_data(void *data) {
 	free(user_cap->src);
 	free(user_cap->dest);
 
-	for (i = 0 ; i < user_cap->num_replies ; i++)
-		free(user_cap->force_data[i]);
-
-	free(user_cap->force_data);
+	if (user_cap->caps == CAP_REPLY) {
+		for (i = 0 ; i < user_cap->data.replies.num ; i++)
+			free(user_cap->data.replies.data[i]);
+		free(user_cap->data.replies.data);
+	}
 }
 
 /*

--- a/src/user_db.c
+++ b/src/user_db.c
@@ -183,8 +183,7 @@ int get_ident(	const struct passwd *pwd,
 		switch (caps) {
 			case CAP_HIDE:
 				if (user_db_have_cap(user_cap, CAP_HIDE) == true) {
-					user_db_cap_destroy_data(user_pref);
-					return (-1);
+					goto out_hide;
 				}
 
 				break;
@@ -237,6 +236,10 @@ int get_ident(	const struct passwd *pwd,
 out_success:
 	user_db_cap_destroy_data(user_pref);
 	return (0);
+
+out_hide:
+	user_db_cap_destroy_data(user_pref);
+	return (-1);
 }
 
 /*

--- a/src/user_db.h
+++ b/src/user_db.h
@@ -35,6 +35,7 @@
 #define CAP_RANDOM_NUMERIC	(1 << 0x06)
 #define CAP_NUMERIC		(1 << 0x07)
 #define CAP_REPLY		(1 << 0x08)
+#define CAP_FORWARD		(1 << 0x09)
 
 #define DB_HASH_SIZE		32
 
@@ -55,6 +56,10 @@ struct user_cap {
 			char **data;
 			u_int8_t num;
 		} replies;
+		struct forward_data {
+			struct sockaddr_storage *host;
+			in_port_t port;
+		} forward;
 	} data;
 };
 

--- a/src/user_db.h
+++ b/src/user_db.h
@@ -49,8 +49,13 @@ struct user_cap {
 
 	u_int16_t caps;
 	u_int16_t action;
-	u_int8_t num_replies;
-	char **force_data;
+
+	union user_cap_data {
+		struct replies_data {
+			char **data;
+			u_int8_t num;
+		} replies;
+	} data;
 };
 
 struct user_info {


### PR DESCRIPTION
These commits implement a `forward` capability available in both `force` and normal forms.

The intended use is to forward requests for certain users to other local ident implementations, when these users are used for running IRC-connected services. For example:

```
user quassel { default { force forward 127.0.0.1 1200 } }
user synapse { default { force forward 127.0.0.1 1113 } }
```

To allow both a local `quasselcore` and a local `matrix-irc-bridge` to spoof ident for their connections via their own ident servers.

A caveat is that the target server doesn't get to see the real client IP, so they must be matching on the `lport` only.

You can forward to other servers than `localhost`, even though that is of dubious use (only `localhost` can make sense of the `lport`). I didn't want to nail this down because you may need to specify IPv4 or IPv6 explicitly. Allowing everything was easier than filtering for the ranges `::1/128`, `127.0.0.0/8` or various `localhost` variants.

You can `allow forward` and let users specify `forward` themselves. I implemented it mostly for completeness (there were no `force`-only capabilities). I'm not making use of this myself so I'm not sure this is of use either. Failure handling is a bit weird as without `allow hide` it responds with the real pwname.
