### PR TITLE
Fix overflow by using proper type for sizeof

### DIFF
--- a/src/inet_util.c
+++ b/src/inet_util.c
@@ -421,7 +421,7 @@ inline bool sin6_equal(	struct sockaddr_storage *ss1,
 void sin_setv6(struct in6_addr *sin6, struct sockaddr_storage *ss) {
 	memset(ss, 0, sizeof(struct sockaddr_storage));
 	ss->ss_family = AF_INET6;
-	memcpy(&SIN6(ss)->sin6_addr, sin6, sizeof(struct sockaddr_in6));
+	memcpy(&SIN6(ss)->sin6_addr, sin6, sizeof(struct in6_addr));
 }
 
 #endif


### PR DESCRIPTION
Running oidentd with address sanitizer (-fsanitize=address in CFLAGS+LDFLAGS) reveals a buffer overflow in the function sin_setv6().

The code:
```
void sin_setv6(struct in6_addr *sin6, struct sockaddr_storage *ss) {
	memset(ss, 0, sizeof(struct sockaddr_storage));
	ss->ss_family = AF_INET6;
	memcpy(&SIN6(ss)->sin6_addr, sin6, sizeof(struct in6_addr));
}
```

The problem seems to be that it's doing a memcpy with sizeof(struct in6_addr) as the length, however both the source and the target are in6_addr. These don't have the same size (28 vs. 16 byte), so there's an overflow.

This pull request should fix this by using the correct type.


For the record, here's the ASAN error report:
```
==21122==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7fffe94d3ee0 at pc 0x0000004c94d9 bp 0x7fffe94d35b0 sp 0x7fffe94d2d60
READ of size 28 at 0x7fffe94d3ee0 thread T0
    #0 0x4c94d8 in __asan_memcpy (/tmp/g/oi1/src/oidentd+0x4c94d8)
    #1 0x500e89 in sin_setv6 /tmp/g/oi1/src/inet_util.c:424:2
    #2 0x4fc3eb in service_request /tmp/g/oi1/src/oidentd.c:323:3
    #3 0x4fb983 in main /tmp/g/oi1/src/oidentd.c
    #4 0x7fec3db73f1a in __libc_start_main (/lib64/libc.so.6+0x23f1a)
    #5 0x41c599 in _start (/tmp/g/oi1/src/oidentd+0x41c599)

Address 0x7fffe94d3ee0 is located in stack of thread T0 at offset 2304 in frame
    #0 0x4fb99f in service_request /tmp/g/oi1/src/oidentd.c:211

  This frame has 17 object(s):
    [32, 36) 'lport_temp' (line 215)
    [48, 52) 'fport_temp' (line 216)
    [64, 192) 'line' (line 219)
    [224, 736) 'suser' (line 220)
    [800, 1056) 'host_buf' (line 221)
    [1120, 1166) 'ip_buf' (line 222)
    [1200, 1328) 'laddr' (line 223)
    [1360, 1488) 'laddr6' (line 223)
    [1520, 1648) 'faddr' (line 223)
    [1680, 1808) 'faddr6' (line 223)
    [1840, 1888) 'pwd' (line 224)
    [1920, 1924) 'fuzz_faddr' (line 227)
    [1936, 1940) 'fuzz_laddr' (line 227)
    [1952, 1956) 'in4' (line 257)
    [1968, 2096) 'laddr_m6' (line 319)
    [2128, 2256) 'faddr_m6' (line 319)
    [2288, 2304) 'in6' (line 320) <== Memory access at offset 2304 overflows this variable
